### PR TITLE
fall after attacks with aerial hitpush

### DIFF
--- a/Player/State/State.cs
+++ b/Player/State/State.cs
@@ -108,6 +108,10 @@ public abstract class State : Node
             push.x *= -1;
         }
         owner.velocity = push;
+        if (owner.velocity.y < 0)
+        {
+            owner.grounded = false;
+        }
         if (height == HEIGHT.HIGH) 
         {
             if (!owner.CheckHeldKey('2'))


### PR DESCRIPTION
The HitStun state checks whether the player is touching the grounding when deciding if it should apply gravity as well as exit into the falling animation.  Before this fix, a DP would result in the struck player floating in the air