### PR TITLE
new hitpush calculation

### DIFF
--- a/Hadouken/HadoukenPart.cs
+++ b/Hadouken/HadoukenPart.cs
@@ -11,7 +11,10 @@ public class HadoukenPart : Node2D
     public int hitStun = 10;
 
     [Export]
-    public Vector2 hitPush = new Vector2();
+    public Vector2 launch = new Vector2();
+
+    [Export]
+    public int hitPush = 0;
 
     [Export]
     public int dmg = 1;
@@ -100,7 +103,7 @@ public class HadoukenPart : Node2D
     private void HurtPlayer()
     {
         // fill this with harmful stuff!!!!
-        targetPlayer.ReceiveHit(movingRight, dmg, hitStun, State.HEIGHT.MID, hitPush, false);
+        targetPlayer.ReceiveHit(movingRight, dmg, hitStun, State.HEIGHT.MID, hitPush, launch, false);
         MakeInactive();
     }
 

--- a/Player/Player.tscn
+++ b/Player/Player.tscn
@@ -2531,7 +2531,7 @@ launch = Vector2( 150, 300 )
 [node name="Jab" type="Node" parent="StateTree"]
 script = ExtResource( 21 )
 hitStun = 12
-hitPush = Vector2( 100, 0 )
+hitPush = 2000
 
 [node name="JumpPunch" type="Node" parent="StateTree"]
 script = ExtResource( 22 )

--- a/Player/State/BaseAttack.cs
+++ b/Player/State/BaseAttack.cs
@@ -9,7 +9,10 @@ public abstract class BaseAttack : State
     protected int hitStun = 10;
 
     [Export]
-    protected Vector2 hitPush = new Vector2();
+    protected Vector2 opponentLaunch = new Vector2();
+
+    [Export]
+    protected int hitPush = 0;
 
     [Export]
     protected HEIGHT height = HEIGHT.MID;
@@ -21,7 +24,7 @@ public abstract class BaseAttack : State
     protected bool knockdown = false;
 
     [Signal]
-    public delegate void OnHitConnected(Vector2 hitPush);
+    public delegate void OnHitConnected(int hitPush);
 
     
 
@@ -79,7 +82,7 @@ public abstract class BaseAttack : State
         {
             GD.Print($"Hit connect on frame {frameCount}");
             EmitSignal(nameof(OnHitConnected), hitPush);
-            owner.otherPlayer.ReceiveHit(owner.OtherPlayerOnRight(), dmg, hitStun, height, hitPush, knockdown);
+            owner.otherPlayer.ReceiveHit(owner.OtherPlayerOnRight(), dmg, hitStun, height, hitPush, opponentLaunch, knockdown);
             hitConnect = true;
         }
 

--- a/Player/State/Hitstun.cs
+++ b/Player/State/Hitstun.cs
@@ -48,13 +48,21 @@ public class HitStun : State
         }
     }
 
-    public override void ReceiveHit(bool rightAttack, HEIGHT height, Vector2 push, bool knockdown)
+    public override void ReceiveHit(bool rightAttack, HEIGHT height, int hitPush, Vector2 launch, bool knockdown)
     {
+        GD.Print($"Received attack on side {rightAttack}");
         if (!rightAttack)
         {
-            push.x *= -1;
+            launch.x *= -1;
+            hitPush *= -1;
         }
-        owner.velocity = push;
+        if (!(launch == Vector2.Zero)) // LAUNCH NEEDS MORE WORK
+        {
+            GD.Print("Launch is not zero!");
+            owner.velocity = launch;
+        }
+
+        owner.hitPushRemaining = hitPush;
         EnterHitState(knockdown);
 
     }

--- a/Player/State/Knockdown.cs
+++ b/Player/State/Knockdown.cs
@@ -22,7 +22,7 @@ public class Knockdown : State
         }
     }
 
-    public override void ReceiveHit(bool rightAttack, HEIGHT height, Vector2 push, bool knockdown)
+    public override void ReceiveHit(bool rightAttack, HEIGHT height, int hitPush, Vector2 launch, bool knockdown)
     {
         // No OTG
     }

--- a/Player/State/State.cs
+++ b/Player/State/State.cs
@@ -94,15 +94,22 @@ public abstract class State : Node
         }
     }
 
-    public virtual void ReceiveHit(bool rightAttack, HEIGHT height, Vector2 push, bool knockdown)
+    public virtual void ReceiveHit(bool rightAttack, HEIGHT height, int hitPush, Vector2 launch, bool knockdown)
     {
-        // need to handle for knockdown!!!
         GD.Print($"Received attack on side {rightAttack}");
         if (!rightAttack)
         {
-            push.x *= -1;
+            launch.x *= -1;
+            hitPush *= -1;
         }
-        owner.velocity = push;
+        if (!(launch == Vector2.Zero)) // LAUNCH NEEDS MORE WORK
+        {
+            GD.Print("Launch is not zero!");
+            owner.velocity = launch;
+        }
+
+        owner.hitPushRemaining = hitPush;
+
         if (owner.velocity.y < 0)
         {
             owner.grounded = false;


### PR DESCRIPTION
HitPush sets a number of pixels the player is required to move rather than applying a velocity.  Launch applies a velocity to the struck player.